### PR TITLE
Append city council district numbers to latest collisions

### DIFF
--- a/district_helper.py
+++ b/district_helper.py
@@ -1,0 +1,36 @@
+import pandas as pd
+import geopandas as gpd
+from shapely.geometry import Point, Polygon
+from shapely import wkt
+
+
+def load_data(collision_file, boundary_file):
+    # Load collision data
+    collisions = pd.read_csv(collision_file)
+    
+    # Ensure lat/lon columns exist
+    if 'latitude' not in collisions.columns or 'longitude' not in collisions.columns:
+        raise ValueError("Collision file must contain 'latitude' and 'longitude' columns")
+    
+    # Convert to GeoDataFrame
+    collisions['geometry'] = collisions.apply(lambda row: Point(row['longitude'], row['latitude']), axis=1)
+    collisions_gdf = gpd.GeoDataFrame(collisions, geometry='geometry', crs='EPSG:4326')
+    
+    # Load city council boundaries
+    boundaries = pd.read_csv(boundary_file)
+    
+    # Ensure necessary columns exist
+    if 'the_geom' not in boundaries.columns or 'CounDist' not in boundaries.columns:
+        raise ValueError("Boundary file must contain 'the_geom' (polygon) and 'CounDist' columns")
+    
+    # Convert WKT polygons to shapely objects
+    boundaries['geometry'] = boundaries['the_geom'].apply(lambda x: wkt.loads(x))
+    boundaries['CounDist'] = boundaries['CounDist'].astype(int)
+    boundaries_gdf = gpd.GeoDataFrame(boundaries, geometry='geometry', crs='EPSG:4326')
+    
+    return collisions_gdf, boundaries_gdf
+
+def assign_districts(collisions_gdf, boundaries_gdf):
+    # Spatial join to find which district each collision falls into
+    merged = gpd.sjoin(collisions_gdf, boundaries_gdf, how='left', predicate='within')
+    return merged

--- a/scrape.py
+++ b/scrape.py
@@ -3,6 +3,7 @@ import pandas as pd
 from datetime import datetime
 import sys
 import json
+from district_helper import load_data, assign_districts
 
 try:
     client = Socrata("data.cityofnewyork.us", None)
@@ -26,6 +27,7 @@ try:
     
     if 'location' in df.columns:
         df['location'] = df['location'].apply(lambda x: json.dumps(x) if isinstance(x, dict) else x)
+
     
     print(f"Retrieved {len(df)} records")
     print(f"Date range: {df['crash_date'].min()} to {df['crash_date'].max()}")
@@ -34,6 +36,22 @@ try:
     output_file = 'latest_collisions.csv'
     df.to_csv(output_file, index=False)
     print(f"Data saved to {output_file}")
+
+     # Assign districts using district_helper
+    collision_file = 'latest_collisions.csv'
+    boundary_file = 'city_council_boundaries.csv'
+    
+    try:
+        collisions_gdf, boundaries_gdf = load_data(collision_file, boundary_file)
+        merged_gdf = assign_districts(collisions_gdf, boundaries_gdf)
+        
+        # Drop unwanted columns before saving
+        columns_to_drop = ["geometry", "index_right", "the_geom", "Shape_Leng", "Shape_Area"]
+        # Save the updated CSV with district information
+        merged_gdf.drop(columns=columns_to_drop, errors="ignore").to_csv(output_file, index=False)
+        print(f"Updated data saved with districts to {output_file}")
+    except Exception as district_error:
+        print(f"Error assigning districts: {str(district_error)}")
     
     summary = {
         'record_count': len(df),


### PR DESCRIPTION
"Added `district_helper`, which converts CSV data into formats compatible with `shapely/geopandas` and performs a spatial join between `latest_collisions.csv` and `city_council_boundaries.csv`. This maps each collision to its corresponding city council district based on geographic boundaries."