### PR TITLE
fetch net new crashes

### DIFF
--- a/scripts/scrape.py
+++ b/scripts/scrape.py
@@ -6,19 +6,21 @@ import json
 from district_helper import load_data, assign_districts
 
 try:
+    latest_data_file = "../data/latest_collisions.csv"
+    df_existing = pd.read_csv(latest_data_file, usecols=["collision_id"])
+    latest_collision_id = df_existing["collision_id"].max()  # Get latest ID
+    print(latest_collision_id)
+
     client = Socrata("data.cityofnewyork.us", None)
     
     today = datetime.now().strftime('%Y-%m-%d')
     
-    # only pulling 1K for now. will probably need a key to bump this up? 
-    query = """
-    SELECT *
-    ORDER BY crash_date DESC
-    LIMIT 1000
-    """
+    initial_date = "2025-02-11"  
+    query = f"SELECT * WHERE collision_id > {latest_collision_id} ORDER BY crash_date DESC LIMIT 1000"
+
     
     results = client.get("h9gi-nx95", query=query)
-    
+
     if not results:
         print("Error: No data retrieved!")
         sys.exit(1)
@@ -33,13 +35,13 @@ try:
     print(f"Date range: {df['crash_date'].min()} to {df['crash_date'].max()}")
     print(f"Boroughs represented: {df['borough'].unique().tolist()}")
     
-    output_file = 'latest_collisions.csv'
+    output_file = '../data/latest_collisions.csv'
     df.to_csv(output_file, index=False)
     print(f"Data saved to {output_file}")
 
      # Assign districts using district_helper
-    collision_file = 'latest_collisions.csv'
-    boundary_file = 'city_council_boundaries.csv'
+    collision_file = '../data/latest_collisions.csv'
+    boundary_file = '../data/city_council_boundaries.csv'
     
     try:
         collisions_gdf, boundaries_gdf = load_data(collision_file, boundary_file)


### PR DESCRIPTION
This should address the following [issue](https://github.com/deblnia/collisions-scrape/issues/1): 
> We'll probably only want net new crashes so we don't send redundant emails. We should watch Github's diff functionality to make sure it's actually diffing the CSV.

I took a different approach leveraging the fact that each crash has a unique `collision_id`, that I assume is sequential/increasing. Basically, I take the latest collision_id from the latest collisions csv and only fetch crashes greater than than the latest `collision_id`. I considered using the latest `crash_date` but I think some crashes are added retroactively, so I don't want to miss those. 

The way I tested this was deleting all but one of the entries in `latest_collisions.csv`, leaving one with a relatively old `collision_id` and then I ran the script. Seemed to work as expected. 

